### PR TITLE
[UI/UX] 게시글 카드 제목 및 해시태그 반응형 레이아웃 최적화

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -52,10 +52,10 @@
                  class="group bg-white border border-border rounded-custom p-8 shadow-custom hover:shadow-custom-hover hover:border-accent hover:-translate-y-1 transition-all duration-300 cursor-pointer"
                  th:onclick="|location.href='@{/posts/{id}(id=${post.id})}'|">
 
-                <div class="flex justify-between items-start mb-6">
-                    <h3 class="text-[1.4rem] font-black text-primary group-hover:text-accent transition-colors tracking-tight" th:text="${post.title}">제목</h3>
-                    <div class="flex gap-2 items-center">
-                        <span th:each="tag : ${post.hashtags}" class="text-accent font-bold text-[0.85rem] bg-accent/5 px-2.5 py-1 rounded" th:text="|#${tag.name}|"></span>
+                <div class="flex flex-col md:flex-row md:justify-between md:items-start mb-6 gap-3 md:gap-4">
+                    <h3 class="text-[1.2rem] md:text-[1.4rem] font-black text-primary group-hover:text-accent transition-colors tracking-tight" th:text="${post.title}">제목</h3>
+                    <div class="flex flex-wrap gap-2 items-center">
+                        <span th:each="tag : ${post.hashtags}" class="text-accent font-bold text-[0.75rem] md:text-[0.85rem] bg-accent/5 px-2.5 py-1 rounded border border-accent/10" th:text="|#${tag.name}|"></span>
                     </div>
                 </div>
 


### PR DESCRIPTION
- index.html: 모바일 화면에서 해시태그가 제목 아래로 내려가도록 flex-col 적용
- 화면 크기에 따라 제목 폰트 크기 및 간격(Gap) 유동적 조정
- 좁은 화면에서 텍스트 겹침 현상 방지 및 가독성 향상