### PR TITLE
[Fix] 게시글 상세 페이지 템플릿 처리 오류 수정 

### DIFF
--- a/src/main/java/com/kthowns/bandconnect/post/controller/PostController.java
+++ b/src/main/java/com/kthowns/bandconnect/post/controller/PostController.java
@@ -11,6 +11,7 @@ import com.kthowns.bandconnect.post.service.PostService;
 import com.kthowns.bandconnect.user.entity.User;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -54,8 +55,11 @@ public class PostController {
             Model model,
             @PathVariable @Nullable Long id,
             @AuthenticationPrincipal User user,
-            HttpServletRequest request
+            HttpServletRequest request,
+            HttpSession session
     ) {
+        request.getSession();
+
         if (id == null) {
             return "redirect:/";
         }

--- a/src/main/resources/templates/post/detail.html
+++ b/src/main/resources/templates/post/detail.html
@@ -116,7 +116,8 @@
                 <h2 class="text-2xl font-black text-primary mb-10 text-center tracking-tight">지원 폼</h2>
                 
                 <form id="application-form" th:action="@{/recruits/apply}" method="post" class="space-y-5 text-left"
-                      th:with="availableRecruits=${postDetail.recruits.?[member == null]}">
+                      th:with="allRecruits=${postDetail.recruits ?: #lists.toList({})}, 
+                               availableRecruits=${allRecruits.?[member == null]}">
                     <div>
                         <label class="block text-[0.9rem] font-bold text-primary mb-2">이름</label>
                         <input type="text" name="name" placeholder="이름을 입력하세요" required


### PR DESCRIPTION
[fix: 게시글 상세 페이지 템플릿 처리 오류 수정](https://github.com/kthowns/band-connect/commit/d95af2c42c4d4378f84bca16af9ae6a53372070e)
- templates/post/detail.html: 지원 폼의 리스트 필터링(th:with) 시 발생할 수 있는 NullPointerException 및 SpEL 처리 오류 수정
- recruits 리스트가 null일 경우에 대한 안전장치 추가 및 필터링 로직 최적화
- Controller에서 Session 강제 생성