### PR TITLE
[Fix] 중복 지원 문제 해결 및 Recruit에 대한 비관적 락 비활성화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ local.properties
 # AWS User-specific
 .idea/**/aws.xml
 
+# QueryDSL Generated files
+**/main/generated
+
 # Generated files
 .idea/**/contentModel.xml
 
@@ -96,6 +99,8 @@ local.properties
 # Gradle
 .idea/**/gradle.xml
 .idea/**/libraries
+
+tmp_prompt.txt
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,

--- a/src/main/java/com/kthowns/bandconnect/application/entity/Application.java
+++ b/src/main/java/com/kthowns/bandconnect/application/entity/Application.java
@@ -18,7 +18,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name = "applications")
+@Table(
+    name = "applications",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"recruit_id", "applicant_id"})
+)
 @EntityListeners(AuditingEntityListener.class)
 public class Application {
     @Id

--- a/src/main/java/com/kthowns/bandconnect/application/service/ApplicationService.java
+++ b/src/main/java/com/kthowns/bandconnect/application/service/ApplicationService.java
@@ -30,7 +30,7 @@ public class ApplicationService {
 
     @Transactional
     public void applyApplication(ApplyRecruitRequest request, User user) {
-        Recruit recruit = recruitRepository.findByIdWithPostAndAuthorWithLock(request.getRecruitId())
+        Recruit recruit = recruitRepository.findByIdWithPostAndAuthor(request.getRecruitId())
                 .orElseThrow(() -> new CustomException(CustomResponseCode.RECRUIT_NOT_FOUND));
 
         /* 자신의 구인글에 대한 지원 제한

--- a/src/main/java/com/kthowns/bandconnect/auth/controller/AuthController.java
+++ b/src/main/java/com/kthowns/bandconnect/auth/controller/AuthController.java
@@ -1,19 +1,9 @@
 package com.kthowns.bandconnect.auth.controller;
 
-import com.kthowns.bandconnect.common.exception.CustomException;
-import com.kthowns.bandconnect.common.exception.CustomResponseCode;
-import com.kthowns.bandconnect.user.dto.SignupRequest;
-import com.kthowns.bandconnect.user.service.UserService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Slf4j
 @Controller

--- a/src/main/java/com/kthowns/bandconnect/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/kthowns/bandconnect/recruit/repository/RecruitRepository.java
@@ -1,9 +1,7 @@
 package com.kthowns.bandconnect.recruit.repository;
 
 import com.kthowns.bandconnect.recruit.entity.Recruit;
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,12 +17,11 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long> {
 
     List<Recruit> findByRecruitPost_Id(Long recruitPostId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r FROM Recruit r" +
             " JOIN FETCH r.recruitPost rp" +
             " JOIN FETCH rp.author" +
             " WHERE r.id = :id")
-    Optional<Recruit> findByIdWithPostAndAuthorWithLock(@Param("id") Long id);
+    Optional<Recruit> findByIdWithPostAndAuthor(@Param("id") Long id);
 
     Optional<Recruit> findByIdAndRecruitPost_Author_Id(Long id, Long userId);
 

--- a/src/main/java/com/kthowns/bandconnect/user/entity/User.java
+++ b/src/main/java/com/kthowns/bandconnect/user/entity/User.java
@@ -10,7 +10,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.List;
 
 @Getter
 @Setter


### PR DESCRIPTION
- Recruit 조회에 대한 Lock 적용 시 성능에 유의미한 성능 저하 발생 예상됨
- Application 테이블의 Unique 제약 조건을 통해 따닥 문제 해결